### PR TITLE
Support for continuous tails

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 
 [![Master build status](https://github.com/streamdal/python-sdk/actions/workflows/main.yml/badge.svg)](https://github.com/streamdal/python-sdk/actions/workflows/main.yml)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/056c5faddeefeed37fcb/test_coverage)](https://codeclimate.com/github/streamdal/python-sdk/test_coverage)
-[![Maintainability](https://api.codeclimate.com/v1/badges/056c5faddeefeed37fcb/maintainability)](https://codeclimate.com/github/streamdal/python-sdk/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/75e54383c741bd7c1bca/test_coverage)](https://codeclimate.com/github/streamdal/python-sdk/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/75e54383c741bd7c1bca/maintainability)](https://codeclimate.com/github/streamdal/python-sdk/maintainability)
+[![GitHub](https://img.shields.io/github/license/streamdal/python-sdk)](https://github.com/streamdal/python-sdk)
 
 python-sdk is the python client SDK for Streamdal's open source observability server https://github.com/streamdal/server
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ requests-toolbelt==1.0.0
 rfc3986==2.0.0
 rich==13.4.2
 six==1.16.0
-streamdal-protos==0.0.115
+streamdal-protos==0.0.118
 stringcase==1.2.0
 tf==1.0.0
 twine==4.0.2

--- a/streamdal/tail/__init__.py
+++ b/streamdal/tail/__init__.py
@@ -23,6 +23,7 @@ class Tail:
     queue: SimpleQueue = SimpleQueue()
     last_msg: int = 0
     log: logging.Logger = logging.getLogger("streamdal-python-sdk")
+    active: bool = False
 
     def __init__(
         self,
@@ -32,6 +33,7 @@ class Tail:
         auth_token: str,
         log: logging.Logger,
         metrics: Metrics,
+        active: bool,
     ):
         self.request = request
         self.queue = SimpleQueue()
@@ -40,6 +42,7 @@ class Tail:
         self.auth_token = auth_token
         self.streamdal_url = streamdal_url
         self.metrics = metrics
+        self.active = active
 
     def tail_iterator(self):
         while not self.exit.is_set():
@@ -56,6 +59,8 @@ class Tail:
                 target=self.start_tail_worker, args=(i + 1,), daemon=False
             )
             incr_worker.start()
+
+        self.active = True
 
     def start_tail_worker(self, worker_id: int):
         self.log.debug(f"Starting tail worker {worker_id}")


### PR DESCRIPTION
* Any in-progress tail commands will come in when `internal.Register()` is called
* Stop all in-progress tails when Register() loses connection, as they will come in when Register() stream is re-established
* If a TailCommand is received for an audience we've seen, start_workers() will be called
* If a TailCommand is received for an unknown audience, it will be stored in the tails map, but not call start_workers()
* When a message is processed and a tail command is found for the audience, workers will be started if `active` == `False`, and `active` will be set to `True`