### PR TITLE
best effort :)

### DIFF
--- a/streamdal/__init__.py
+++ b/streamdal/__init__.py
@@ -857,7 +857,7 @@ class StreamdalClient:
         linker.define_func(
             "env",
             "httpRequest",
-            FuncType([ValType.i32(), ValType.i32()], [ValType.i32()]),
+            FuncType([ValType.i32(), ValType.i32()], [ValType.i64()]),
             hostfunc.http_request,
             True,
         )
@@ -887,7 +887,7 @@ class StreamdalClient:
         # Get alloc() from module
         alloc = instance.exports(store)["alloc"]
         # Allocate enough memory for the length of the data and receive memory pointer
-        start_ptr = alloc(store, len(data) + 64)
+        start_ptr = alloc(store, len(data))
 
         # Write to memory starting at pointer returned bys alloc()
         memory.write(store, data, start_ptr)

--- a/streamdal/__init__.py
+++ b/streamdal/__init__.py
@@ -897,7 +897,7 @@ class StreamdalClient:
         result_ptr = f(store, start_ptr, len(data))
 
         # Read from result pointer
-        return common.read_memory(memory, store, result_ptr)
+        return common.read_memory(memory, store, result_ptr, -1)
 
     # ------------------------------------------------------------------------------------
 

--- a/streamdal/common/__init__.py
+++ b/streamdal/common/__init__.py
@@ -45,7 +45,7 @@ def read_memory(memory: Memory, store, result_ptr: int, length: int = None) -> b
         len_true = mem_len
     elif length == -1:
         ptr_true = result_ptr >> 32
-        len_true = result_ptr
+        len_true = result_ptr & 0xFFFFFFFF
     else:
         ptr_true = result_ptr
         len_true = length
@@ -54,4 +54,4 @@ def read_memory(memory: Memory, store, result_ptr: int, length: int = None) -> b
     # if length is not None or length != -1 and ptr_true > len_true or ptr_true + len_true > mem_len:
     #     raise StreamdalException("WASM memory pointer out of bounds")
 
-    return memory.read(store, ptr_true, len_true)
+    return memory.read(store, ptr_true, ptr_true + len_true)

--- a/streamdal/common/__init__.py
+++ b/streamdal/common/__init__.py
@@ -30,43 +30,28 @@ def str_to_aud(aud: str) -> protos.Audience:
     )
 
 
-def read_memory(memory: Memory, store, result_ptr: int, length: int = -1) -> bytes:
+def read_memory(memory: Memory, store, result_ptr: int, length: int = None) -> bytes:
     """
-    Read a response from a wasm memory buffer using the given length,
-    or until we encounter 3 null bytes in a row.
+    This function has three operation modes:
+
+    1. If you pass a $ptr and $length - it will try to read $length bytes from the $ptr
+    2. If you pass a ptr and pass length as -1 - it will try to unpack size from the $ptr
+    3. If you pass a ptr and do NOT pass length - it will read all memory starting at $ptr
     """
     mem_len = memory.data_len(store)
 
-    # Ensure we aren't reading out of bounds
-    if result_ptr > mem_len or result_ptr + length > mem_len:
-        raise StreamdalException("WASM memory pointer out of bounds")
+    if length is None:
+        ptr_true = result_ptr
+        len_true = mem_len
+    elif length == -1:
+        ptr_true = result_ptr >> 32
+        len_true = result_ptr
+    else:
+        ptr_true = result_ptr
+        len_true = length
 
-    # TODO: can we avoid reading the entire buffer somehow?
-    result_data = memory.read(store, result_ptr, mem_len)
+    # Ensure we aren't reading out of bounds (if we have a real length)
+    # if length is not None or length != -1 and ptr_true > len_true or ptr_true + len_true > mem_len:
+    #     raise StreamdalException("WASM memory pointer out of bounds")
 
-    res = bytearray()  # Used to build our result
-    nulls = 0  # How many null pointers we've encountered
-    count = 0  # How many bytes we've read, used to check against length, if provided
-
-    for v in result_data:
-        if length == count and length != -1:
-            break
-
-        if nulls == 3:
-            break
-
-        if v == 166:
-            nulls += 1
-            res.append(v)
-            continue
-
-        count += 1
-        res.append(v)
-        nulls = 0  # Reset nulls since we read another byte and thus aren't at the end
-
-    if count == len(result_data) and nulls != 3:
-        raise StreamdalException(
-            "unable to read response from wasm - no terminators found in response data"
-        )
-
-    return bytes(res).rstrip(b"\xa6")
+    return memory.read(store, ptr_true, len_true)

--- a/streamdal/hostfunc/__init__.py
+++ b/streamdal/hostfunc/__init__.py
@@ -32,15 +32,14 @@ def http_request(caller: Caller, ptr: int, length: int) -> int:
 
     resp = res.SerializeToString()
 
-    # Append terminator sequence
-    resp += b"\xa6\xa6\xa6"
-
     # Allocate memory for response
     alloc = caller.get("alloc")
     resp_ptr = alloc(caller, len(resp) + 64)
 
     # Write response to memory
     memory.write(caller, resp, resp_ptr)
+
+    resp_ptr = resp_ptr << 32 | len(resp)
 
     return resp_ptr
 
@@ -61,6 +60,6 @@ def __http_request_perform(req: protos.steps.HttpRequest) -> requests.Response:
     elif req.method == protos.steps.HttpRequestMethod.HTTP_REQUEST_METHOD_OPTIONS:
         response = requests.options(req.url)
     else:
-        raise ValueError("Invalid HTTP method provided")
+        raise ValueError(f"Invalid HTTP method provided: '{req.method}'")
 
     return response

--- a/test_common.py
+++ b/test_common.py
@@ -32,20 +32,36 @@ class TestCommon:
         """Test reading within bounds of memory"""
         store = Store()
         memory = Memory(store, MemoryType(Limits(1, 1024)))
-        data = b"Hello, World!\xa6\xa6\xa6"
+        data = b"Hello, World!"
         memory.write(store, data, 0)
 
         result = common.read_memory(memory, store, 0, len(data))
         assert result == b"Hello, World!"
 
-    def test_read_memory_with_interspersed_pointers(self):
-        """Test reading with null pointers"""
+    def test_read_memory_all(self):
+        """Test not passing a length should read all memory"""
         store = Store()
         memory = Memory(store, MemoryType(Limits(1, 1)))
-        data = b"Hel\xa6lo,\xa6 W\xa6orld!\xa6\xa6\xa6"
+        data = b"Hello, world!"
+        memory.write(store, data, 0)
+        result = common.read_memory(memory, store, 0)
+
+        # Allocated memory should be the same as the length of the result data
+        assert memory.data_len(store) == len(result)
+
+        # Beginning of result should contain the data we wrote
+        assert result.startswith(data)
+
+    def test_read_memory_unpack_ptr(self):
+        """Test passing a length of '-1' should unpack the length from the pointer"""
+        store = Store()
+        memory = Memory(store, MemoryType(Limits(1, 1)))
+        data = b"Hello, world!"
+        ptr_packed = 0 << 32 | len(data)
+
+        # Write data from the start
         memory.write(store, data, 0)
 
-        result = common.read_memory(memory, store, 0)
-        assert (
-            result == b"Hel\xa6lo,\xa6 W\xa6orld!"
-        )  # Should NOT stop at the third terminator character
+        result = common.read_memory(memory, store, ptr_packed, -1)
+
+        assert result == data


### PR DESCRIPTION
I *think* I implemented the reading correctly - I managed to fix a couple of tests but am now running into internal errors returned by the WASM modules themselves. Maybe you have some insight.

I basically updated `read_memory()` to allow passing it a real length, length that is None, and length that is -1.

If -1: it'll try to unpack length from ptr
If None: read ALL memory
If any other int: read exact amount of mem

We don't actually need to read all mem ever but this seemed "correct".

I guess you could "unpack if None" but that could cause errors. I figured it's better to _explicitly_ say that we want to unpack something.

:shrug: