### PR TITLE
Pipeline changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/*
 htmlcov/*
 coverage.xml
 coverage/*
+test-assets/wasm/*

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ python -m pip install streamdal
 ### Example Usage
 
 ```python
-import pprint
-from streamdal import (OPERATION_TYPE_CONSUMER, ProcessRequest, StreamdalClient, StreamdalConfig)
+import json
+from streamdal import (OPERATION_TYPE_CONSUMER, ProcessRequest, StreamdalClient, StreamdalConfig, EXEC_STATUS_TRUE)
 
 client = StreamdalClient(
     cfg=StreamdalConfig(
@@ -41,14 +41,18 @@ res = client.process(
         operation_type=OPERATION_TYPE_CONSUMER,
         operation_name="new-order-topic",
         component_name="kafka",
-        data=b'{"object": {"field": true}}',
+        data=b'{"object": {"email": "user@streamdal.com"}}',
     )
 )
 
-if res.error:
-    print(res.message)
+# Check that process() completed successfully
+if res.status == EXEC_STATUS_TRUE:
+    print("Success processed payload")
+    data = json.loads(res.data)
+    print("Response:", json.dumps(data, indent=2))
 else:
-    pprint.pprint(res.data)
+    print("Failed to process payload")
+    print("Error:", res.status_message)
 ```
 
 ### Metrics

--- a/example.py
+++ b/example.py
@@ -1,8 +1,7 @@
-import pprint
 import logging
+import json
 import time
 import logging.config
-
 
 from streamdal import (
     Audience,
@@ -10,6 +9,7 @@ from streamdal import (
     StreamdalConfig,
     ProcessRequest,
     OPERATION_TYPE_CONSUMER,
+    EXEC_STATUS_TRUE,
 )
 
 
@@ -18,7 +18,7 @@ def main():
     client = StreamdalClient(
         cfg=StreamdalConfig(
             service_name="service",
-            dry_run=True,
+            dry_run=False,
             streamdal_url="localhost:8082",
             streamdal_token="1234",
             audiences=[
@@ -31,28 +31,24 @@ def main():
         )
     )
 
-    # req = ProcessRequest(
-    #     operation_type=OPERATION_TYPE_CONSUMER,
-    #     operation_name="opname",
-    #     component_name="comname",
-    #     data=b'{"object": {"field": true}}',
-    # )
-    #
-    # res = client.process(req)
-    #
-    # pprint.pprint(res)
-
     while not client.cfg.exit.is_set():
         time.sleep(5)
         req = ProcessRequest(
             operation_type=OPERATION_TYPE_CONSUMER,
             operation_name="demo-operation",
             component_name="kafka",
-            data=b'{"object": {"field": true}}',
+            data=b'{"object": {"email": "mark@streamdal.com"}}',
         )
         res = client.process(req)
 
-        pprint.pprint(res)
+        # Check that process() completed successfully
+        if res.status == EXEC_STATUS_TRUE:
+            print("Success processed payload")
+            data = json.loads(res.data)
+            print("Response:", json.dumps(data, indent=2))
+        else:
+            print("Failed to process payload")
+            print("Error:", res.status_message)
 
     print("done")
 

--- a/init_wasm.sh
+++ b/init_wasm.sh
@@ -1,23 +1,25 @@
 #!/bin/bash
 
+mkdir -p test-assets/wasm
+
 # Step 1: Curl the GitHub API to get the latest release
-latest_release=$(curl -s https://api.github.com/repos/streamdal/streamdal/releases/latest)
+latest_release=$(curl -s https://api.github.com/repos/streamdal/streamdal/releases)
 
 # Step 2: Extract the "browser_download_url" from the JSON response
-download_url=$(echo "$latest_release" | grep -o 'https://.*\.zip')
+download_url=$(echo "$latest_release" | grep -o 'https://.*/libs/wasm/.*/release\.zip' | head -1)
 
 # Step 3: Add debug info
-mkdir -p assets/test
+mkdir -p test-assets/wasm
 version=$(echo $download_url | cut -d / -f10)
-echo "WASM artifact version: ${version}" > assets/test/version.txt
-echo "Last updated: $(date)" >> assets/test/version.txt
+echo "WASM artifact version: ${version}" > test-assets/wasm/version.txt
+echo "Last updated: $(date)" >> test-assets/wasm/version.txt
 
 # Step 4: Curl the download URL and save as release.zip
 curl -L "$download_url" -o release.zip
 
-# Step 5: Unzip release.zip into the assets/test/ directory
-unzip -o release.zip -d assets/test/
+# Step 5: Unzip release.zip into the test-assets/wasm/ directory
+unzip -o release.zip -d test-assets/wasm/
 
 # Step 6: Clean up & info
 rm release.zip
-cat assets/test/version.txt
+cat test-assets/wasm/version.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ requests-toolbelt==1.0.0
 rfc3986==2.0.0
 rich==13.7.0
 six==1.16.0
-streamdal-protos==0.1.17
+streamdal-protos==0.1.18
 stringcase==1.2.0
 tf==1.0.0
 token-bucket==0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ requests-toolbelt==1.0.0
 rfc3986==2.0.0
 rich==13.7.0
 six==1.16.0
-streamdal-protos==0.1.13
+streamdal-protos==0.1.17
 stringcase==1.2.0
 tf==1.0.0
 token-bucket==0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ importlib-metadata==6.8.0
 iniconfig==2.0.0
 isort==5.12.0
 jaraco.classes==3.3.0
-Jinja2==3.1.2
+Jinja2==3.1.3
 keyring==24.3.0
 markdown-it-py==3.0.0
 MarkupSafe==2.1.3

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "iniconfig==2.0.0",
         "isort==5.12.0",
         "jaraco.classes==3.3.0",
-        "Jinja2==3.1.2",
+        "Jinja2==3.1.3",
         "keyring==24.3.0",
         "markdown-it-py==3.0.0",
         "MarkupSafe==2.1.3",

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
         "rfc3986==2.0.0",
         "rich==13.7.0",
         "six==1.16.0",
-        "streamdal-protos==0.1.17",
+        "streamdal-protos==0.1.18",
         "stringcase==1.2.0",
         "tf==1.0.0",
         "token-bucket==0.3.0",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 setup(
     name="streamdal",
-    version='0.0.46',
+    version="0.0.46",
     description="Python client SDK for Streamdal's open source observability server",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -70,7 +70,7 @@ setup(
         "rfc3986==2.0.0",
         "rich==13.7.0",
         "six==1.16.0",
-        "streamdal-protos==0.1.13",
+        "streamdal-protos==0.1.17",
         "stringcase==1.2.0",
         "tf==1.0.0",
         "token-bucket==0.3.0",

--- a/streamdal/__init__.py
+++ b/streamdal/__init__.py
@@ -497,7 +497,7 @@ class StreamdalClient:
         asyncio.set_event_loop(loop)
         loop.run_until_complete(call())
 
-    def _get_pipelines(self, aud: protos.Audience) -> list[protos.Pipeline]:
+    def _get_pipelines(self, aud: protos.Audience) -> list:
         """
         Get pipelines for a given mode and operation
 

--- a/streamdal/validation/__init__.py
+++ b/streamdal/validation/__init__.py
@@ -22,63 +22,22 @@ def tail_request(cmd: protos.Command):
         raise ValueError("cmd.tail.request.type cannot be unset")
 
 
-def attach_pipeline(cmd: protos.Command):
+def set_pipelines(cmd: protos.Command):
     if not isinstance(cmd, protos.Command):
         raise ValueError("cmd must be a protos.Command")
 
     if not isinstance(cmd.audience, protos.Audience):
         raise ValueError("cmd.audience must be a protos.Audience")
 
-    if not isinstance(cmd.attach_pipeline, protos.AttachPipelineCommand):
-        raise ValueError("cmd.attach_pipeline must be a protos.AttachPipelineCommand")
+    if not isinstance(cmd.set_pipelines, protos.SetPipelinesCommand):
+        raise ValueError("cmd.set_pipelines must be a protos.SetPipelinesCommand")
 
-    if not isinstance(cmd.attach_pipeline.pipeline, protos.Pipeline):
-        raise ValueError("cmd.attach_pipeline.pipeline must be a protos.Pipeline")
+    for pipeline in cmd.set_pipelines.pipelines:
+        if not isinstance(pipeline, protos.Pipeline):
+            raise ValueError("pipeline must be a protos.Pipeline")
 
-    if cmd.attach_pipeline.pipeline.id == "":
-        raise ValueError("cmd.attach_pipeline.pipeline.id must be non-empty")
-
-
-def detach_pipeline(cmd: protos.Command):
-    if not isinstance(cmd, protos.Command):
-        raise ValueError("cmd must be a protos.Command")
-
-    if not isinstance(cmd.audience, protos.Audience):
-        raise ValueError("cmd.audience must be a protos.Audience")
-
-    if not isinstance(cmd.detach_pipeline, protos.DetachPipelineCommand):
-        raise ValueError("cmd.detach_pipeline must be a protos.DetachPipelineCommand")
-
-    if cmd.detach_pipeline.pipeline_id == "":
-        raise ValueError("cmd.detach_pipeline.pipeline.id must be non-empty")
-
-
-def pause_pipeline(cmd: protos.Command):
-    if not isinstance(cmd, protos.Command):
-        raise ValueError("cmd must be a protos.Command")
-
-    if not isinstance(cmd.audience, protos.Audience):
-        raise ValueError("cmd.audience must be a protos.Audience")
-
-    if not isinstance(cmd.pause_pipeline, protos.PausePipelineCommand):
-        raise ValueError("cmd.pause_pipeline must be a protos.PausePipelineCommand")
-
-    if cmd.pause_pipeline.pipeline_id == "":
-        raise ValueError("cmd.pause_pipeline.pipeline.id must be non-empty")
-
-
-def resume_pipeline(cmd: protos.Command):
-    if not isinstance(cmd, protos.Command):
-        raise ValueError("cmd must be a protos.Command")
-
-    if not isinstance(cmd.audience, protos.Audience):
-        raise ValueError("cmd.audience must be a protos.Audience")
-
-    if not isinstance(cmd.resume_pipeline, protos.ResumePipelineCommand):
-        raise ValueError("cmd.resume_pipeline must be a protos.ResumePipelineCommand")
-
-    if cmd.resume_pipeline.pipeline_id == "":
-        raise ValueError("cmd.resume_pipeline.pipeline.id must be non-empty")
+        if pipeline.id == "":
+            raise ValueError("pipeline.id must be non-empty")
 
 
 def kv_command(cmd: protos.Command):

--- a/test_register.py
+++ b/test_register.py
@@ -19,22 +19,6 @@ class TestStreamdalRegisterMethods:
 
         self.client = client
 
-    def test_is_paused(self):
-        """Test is_paused returns True when paused"""
-
-        aud = protos.Audience(
-            component_name="test",
-            operation_type=protos.OperationType.OPERATION_TYPE_PRODUCER,
-        )
-
-        pipeline_id = str(uuid.uuid4())
-        aud_str = common.aud_to_str(aud)
-        self.client.paused_pipelines[aud_str] = {}
-        self.client.paused_pipelines[aud_str][pipeline_id] = protos.Command
-
-        assert self.client._is_paused(aud, str(uuid.uuid4())) is False
-        assert self.client._is_paused(aud, pipeline_id) is True
-
     def test_attach_pipeline(self):
         """Test set_pipeline adds a pipeline to the pipelines dict"""
 
@@ -45,182 +29,17 @@ class TestStreamdalRegisterMethods:
                 component_name="test",
                 operation_type=protos.OperationType.OPERATION_TYPE_PRODUCER,
             ),
-            attach_pipeline=protos.AttachPipelineCommand(
-                pipeline=protos.Pipeline(
-                    id=pipeline_id,
-                )
+            set_pipelines=protos.SetPipelinesCommand(
+                pipelines=[
+                    protos.Pipeline(
+                        id=pipeline_id,
+                    )
+                ],
             ),
         )
 
-        self.client._attach_pipeline(cmd)
+        self.client._set_pipelines(cmd)
 
         aud_str = common.aud_to_str(cmd.audience)
         assert self.client.pipelines[aud_str] is not None
-        assert self.client.pipelines[aud_str][pipeline_id] is not None
-
-    def test_pop_pipeline(self):
-        pipeline_id = str(uuid.uuid4())
-
-        cmd = protos.Command(
-            audience=protos.Audience(
-                component_name="test",
-                operation_type=protos.OperationType.OPERATION_TYPE_PRODUCER,
-            ),
-            attach_pipeline=protos.AttachPipelineCommand(
-                pipeline=protos.Pipeline(
-                    id=pipeline_id,
-                )
-            ),
-        )
-
-        self.client._attach_pipeline(cmd)
-
-        pipeline = StreamdalClient._pop_pipeline(
-            self.client.pipelines, cmd, pipeline_id
-        )
-
-        assert pipeline is not None
-        assert pipeline.attach_pipeline.pipeline.id == pipeline_id
-
-    def test_pause_resume_pipeline(self):
-        pipeline_id = str(uuid.uuid4())
-
-        cmd = protos.Command(
-            audience=protos.Audience(
-                component_name="test",
-                service_name="testing",
-                operation_type=protos.OperationType.OPERATION_TYPE_PRODUCER,
-            ),
-            attach_pipeline=protos.AttachPipelineCommand(
-                pipeline=protos.Pipeline(
-                    id=pipeline_id,
-                )
-            ),
-        )
-
-        self.client._attach_pipeline(cmd)
-
-        pause_cmd = protos.Command(
-            audience=protos.Audience(
-                component_name="test",
-                service_name="testing",
-                operation_type=protos.OperationType.OPERATION_TYPE_PRODUCER,
-            ),
-            pause_pipeline=protos.PausePipelineCommand(
-                pipeline_id=pipeline_id,
-            ),
-        )
-
-        with pytest.raises(ValueError, match="cmd must be a protos.Command"):
-            self.client._pause_pipeline(None)
-
-        res = self.client._pause_pipeline(pause_cmd)
-        assert res is True
-
-        aud_str = common.aud_to_str(cmd.audience)
-        assert len(self.client.paused_pipelines) == 1
-        assert len(self.client.pipelines) == 0
-        assert self.client.paused_pipelines[aud_str] is not None
-        assert self.client.paused_pipelines[aud_str][pipeline_id] is not None
-
-        resume_cmd = protos.Command(
-            audience=protos.Audience(
-                component_name="test",
-                service_name="testing",
-                operation_type=protos.OperationType.OPERATION_TYPE_PRODUCER,
-            ),
-            resume_pipeline=protos.ResumePipelineCommand(
-                pipeline_id=pipeline_id,
-            ),
-        )
-
-        with pytest.raises(ValueError, match="cmd must be a protos.Command"):
-            self.client._resume_pipeline(None)
-
-        res = self.client._resume_pipeline(resume_cmd)
-        assert res is True
-
-        aud_str = common.aud_to_str(cmd.audience)
-        assert len(self.client.paused_pipelines) == 0
-        assert len(self.client.pipelines) == 1
-        assert self.client.pipelines[aud_str] is not None
-        assert self.client.pipelines[aud_str][pipeline_id] is not None
-
-    def test_detach_pipeline(self):
-        pipeline_id = str(uuid.uuid4())
-
-        cmd = protos.Command(
-            audience=protos.Audience(
-                component_name="kafka",
-                service_name="testing",
-                operation_name="test-topic",
-                operation_type=protos.OperationType.OPERATION_TYPE_PRODUCER,
-            ),
-            attach_pipeline=protos.AttachPipelineCommand(
-                pipeline=protos.Pipeline(
-                    id=pipeline_id,
-                )
-            ),
-        )
-
-        self.client._attach_pipeline(cmd)
-
-        delete_cmd = protos.Command(
-            audience=protos.Audience(
-                component_name="kafka",
-                service_name="testing",
-                operation_name="test-topic",
-                operation_type=protos.OperationType.OPERATION_TYPE_PRODUCER,
-            ),
-            detach_pipeline=protos.DetachPipelineCommand(
-                pipeline_id=pipeline_id,
-            ),
-        )
-
-        with pytest.raises(ValueError, match="cmd must be a protos.Command"):
-            self.client._detach_pipeline(None)
-
-        res = self.client._detach_pipeline(delete_cmd)
-        assert res is True
-        assert len(self.client.pipelines) == 0
-        assert len(self.client.paused_pipelines) == 0
-
-    def test_get_pipelines(self):
-        pipeline_id = str(uuid.uuid4())
-
-        cmd = protos.Command(
-            audience=protos.Audience(
-                component_name="kafka",
-                service_name="testing",
-                operation_name="test-topic",
-                operation_type=protos.OperationType.OPERATION_TYPE_PRODUCER,
-            ),
-            attach_pipeline=protos.AttachPipelineCommand(
-                pipeline=protos.Pipeline(
-                    id=pipeline_id,
-                )
-            ),
-        )
-
-        self.client._attach_pipeline(cmd)
-        res = self.client._get_pipelines(
-            protos.Audience(
-                component_name="kafka",
-                service_name="testing",
-                operation_name="test-topic",
-                operation_type=protos.OperationType.OPERATION_TYPE_CONSUMER,
-            )
-        )
-        assert len(res) == 0
-
-        res = self.client._get_pipelines(
-            protos.Audience(
-                component_name="kafka",
-                service_name="testing",
-                operation_name="test-topic",
-                operation_type=protos.OperationType.OPERATION_TYPE_PRODUCER,
-            )
-        )
-        assert len(res) == 1
-        k, v = res.popitem()
-        assert v.attach_pipeline.pipeline.id == pipeline_id
+        assert len(self.client.pipelines[aud_str]) == 1

--- a/test_register.py
+++ b/test_register.py
@@ -19,7 +19,7 @@ class TestStreamdalRegisterMethods:
 
         self.client = client
 
-    def test_attach_pipeline(self):
+    def test_set_pipelines(self):
         """Test set_pipeline adds a pipeline to the pipelines dict"""
 
         pipeline_id = str(uuid.uuid4())

--- a/test_validation.py
+++ b/test_validation.py
@@ -58,61 +58,60 @@ class TestTailRequest:
             validation.tail_request(self.cmd)
 
 
-class TestAttachPipeline:
+class TestSetPipelines:
     def test_valid_input(self):
         # Create a valid protos.Command object
         cmd = protos.Command(
             audience=protos.Audience(),
-            attach_pipeline=protos.AttachPipelineCommand(
-                pipeline=protos.Pipeline(id="some_id")
+            set_pipelines=protos.SetPipelinesCommand(
+                pipelines=[protos.Pipeline(id="some_id")]
             ),
         )
 
         # The function should not raise any exceptions for valid input
-        validation.attach_pipeline(cmd)
+        validation.set_pipelines(cmd)
 
     def test_invalid_command_type(self):
         with pytest.raises(ValueError, match="cmd must be a protos.Command"):
-            validation.attach_pipeline(
+            validation.set_pipelines(
                 None
             )  # Passing a mock object instead of a protos.Command
 
     def test_invalid_audience_type(self):
         invalid_cmd = protos.Command(
-            audience=protos.Command(),
-            attach_pipeline=protos.AttachPipelineCommand(
-                pipeline=protos.Pipeline(id="some_id")
+            audience=None,
+            set_pipelines=protos.SetPipelinesCommand(
+                pipelines=[protos.Pipeline(id="some_id")]
             ),
         )
         with pytest.raises(ValueError, match="cmd.audience must be a protos.Audience"):
-            validation.attach_pipeline(invalid_cmd)
+            validation.set_pipelines(invalid_cmd)
 
     def test_invalid_attach_pipeline_type(self):
         invalid_cmd = protos.Command(
-            audience=protos.Audience(), attach_pipeline=protos.Command()
+            audience=protos.Audience(),
+            set_pipelines=None,
         )
         with pytest.raises(
             ValueError,
-            match="cmd.attach_pipeline must be a protos.AttachPipelineCommand",
+            match="cmd.set_pipelines must be a protos.SetPipelinesCommand",
         ):
-            validation.attach_pipeline(invalid_cmd)
+            validation.set_pipelines(invalid_cmd)
 
     def test_invalid_pipeline_type(self):
         invalid_cmd = protos.Command(
             audience=protos.Audience(),
-            attach_pipeline=protos.AttachPipelineCommand(pipeline=protos.Pipeline()),
+            set_pipelines=protos.SetPipelinesCommand(pipelines=[protos.Pipeline()]),
         )
         with pytest.raises(ValueError):
-            validation.attach_pipeline(invalid_cmd)
+            validation.set_pipelines(invalid_cmd)
 
     def test_empty_pipeline_id(self):
         invalid_cmd = protos.Command(
             audience=protos.Audience(),
-            attach_pipeline=protos.AttachPipelineCommand(
-                pipeline=protos.Pipeline(id="")
+            set_pipelines=protos.SetPipelinesCommand(
+                pipelines=[protos.Pipeline(id="")]
             ),
         )
-        with pytest.raises(
-            ValueError, match="cmd.attach_pipeline.pipeline.id must be non-empty"
-        ):
-            validation.attach_pipeline(invalid_cmd)
+        with pytest.raises(ValueError, match="pipeline.id must be non-empty"):
+            validation.set_pipelines(invalid_cmd)


### PR DESCRIPTION
* We now return `true`, `false`, or `error` for pipeline and step statuses
* Removed attach/detatch/pause/resume commands. All pipelines are now received via SetPipelinesCommand
* Moved `assets/test` to `test-assets/wasm` to match go-sdk's structure
* Fixed `init_wasm.sh` to deal with github API response when protos aren't available in `/latest` API endpoint